### PR TITLE
Redesign homepage services section and add new content sections

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -45,7 +45,7 @@ pagerSize = 6
 [[menu.main]]
   identifier = 'retainer'
   url = '/retainer'
-  name = 'Retainer Plans'
+  name = 'Managed AWS Support'
   parent = 'products'
   weight = 5
 [[menu.main]]

--- a/content/_index.md
+++ b/content/_index.md
@@ -20,7 +20,7 @@ images: [ 'featured.png' ]
 {{< service_item title="Amazon Bedrock in Production" description="Deploy AI securely in production for startups and regulated companies alike." url="/ai-to-production/" >}}
 {{< service_item title="Cloud Migration to AWS" description="Seamlessly move your infrastructure to AWS so you can focus on your product, not the move." url="/aws-migration/" >}}
 {{< service_item title="AWS Security Review" description="Audit your existing AWS setup and get a clear picture of your security posture and what to fix." url="/contact/" >}}
-{{< service_item title="Ongoing Retainer" description="Continuous cloud engineering support after the initial build - we stay on as your dedicated AWS team." url="/retainer/" >}}
+{{< service_item title="Managed AWS Support" description="Continuous cloud engineering support after the initial build - we stay on as your dedicated AWS team." url="/retainer/" >}}
 {{< /services_grid >}}
 
 {{< two_columns heading="Why Startups Choose FivexL" >}}

--- a/content/_index.md
+++ b/content/_index.md
@@ -14,29 +14,31 @@ transparent_nav: true
 images: [ 'featured.png' ]
 ---
 
-{{< two_columns heading="FivexL - Cloud Engineering Specialists" >}}
-{{< column >}}
-### What Can We Do For Your Startup?  
-- We build <strong style="color:#F13687">HIPAA and SOC 2-ready AWS foundations</strong> for healthcare, fintech, and other highly regulated startups - secure from day one with [RightStart](/rightstart/).
-- We take your infrastructure to the next level so it grows with you - from first prototype to production scale with [ECS Blueprint](/ecs-blueprint/).
-- We deploy <strong style="color:#F13687">Amazon Bedrock securely in production</strong> for startups and regulated companies alike. [Learn more](/ai-to-production/).
-- We handle <strong style="color:#F13687">cloud migrations to AWS</strong> so you can focus on your product, not the move with [Cloud Migration](/aws-migration/).
-- We bring <strong style="color:#F13687">cost predictability to your AWS spend</strong> - no nasty surprises.  
-{{< /column >}}
+{{< services_grid heading="What Can We Do For Your Startup?" >}}
+{{< service_item title="HIPAA & SOC 2-Ready AWS Foundations" description="Secure infrastructure for healthcare, fintech, and other regulated startups - built right from day one." url="/rightstart/" >}}
+{{< service_item title="Production-Ready ECS Infrastructure" description="Take your infrastructure to the next level so it grows with you - from first prototype to production scale." url="/ecs-blueprint/" >}}
+{{< service_item title="Amazon Bedrock in Production" description="Deploy AI securely in production for startups and regulated companies alike." url="/ai-to-production/" >}}
+{{< service_item title="Cloud Migration to AWS" description="Seamlessly move your infrastructure to AWS so you can focus on your product, not the move." url="/aws-migration/" >}}
+{{< service_item title="AWS Security Review" description="Audit your existing AWS setup and get a clear picture of your security posture and what to fix." url="/contact/" >}}
+{{< service_item title="Ongoing Retainer" description="Continuous cloud engineering support after the initial build - we stay on as your dedicated AWS team." url="/retainer/" >}}
+{{< /services_grid >}}
 
+{{< two_columns heading="Why Startups Choose FivexL" >}}
 {{< column >}}
-### Why Startups Choose FivexL  
 - We are an AWS Advanced Tier Partner with 50+ years of combined cloud engineering experience.
 - We build everything as infrastructure as code - no manual changes, no human mistakes.
 - We specialize in security - HIPAA, SOC 2, and audit readiness are built in from day one, not bolted on later.
 - We keep your AWS bill predictable as you scale.
 - We take full responsibility for your infrastructure and deliver it fully transparent, fully yours.
+- Deep experience with healthcare and startups in highly regulated environments.
 {{< /column >}}
 {{< /two_columns >}}
 
 <!-- {{< section heading="AWS Advanced Partner" >}}
 As an AWS Advanced Partner, FivexL combines real-world experience with deep knowledge in building scalable, secure, and cost-effective AWS environments for fast-growing startups. 
 {{< /section >}} -->
+
+{{< customer_logos heading="Trusted by startups worldwide" >}}
 
 {{< our_team heading="Our Team" cta_url="/contact" cta_text="Book a consultation" >}}
 {{< md >}}
@@ -61,5 +63,7 @@ There’s no problem that we can’t solve together!
 
 {{< case_studies_cards heading="Our happy customers" mb="3">}}
 
-{{< callout_cta heading="This way, you can focus on what you do best without worrying about the underlying infrastructure." cta_url="/contact" cta_text="Book a consultation" >}}
+{{< latest_posts heading="Latest from FivexL" >}}
+
+{{< callout_cta heading="Focus on what you do best without worrying about the underlying infrastructure" cta_url="/contact" cta_text="Book a consultation" >}}
 

--- a/content/retainer/index.md
+++ b/content/retainer/index.md
@@ -1,5 +1,5 @@
 ---
-title: 'FivexL Retainer Plans'
+title: 'FivexL Managed AWS Support'
 summary: 'Tailored support plans for existing FivexL customers. Choose between Keep the Lights On for infrastructure maintenance or Trusted Advisor for team empowerment and guidance.'
 date: 2025-12-12
 url: "/retainer/"
@@ -12,23 +12,23 @@ _build:
 transparent_nav: true
 callout_cta_heading: "Ready to secure ongoing support for your infrastructure?"
 callout_cta_url: "#retainer-popup"
-callout_cta_text: "Get a Retainer Quote"
+callout_cta_text: "Get a Quote"
 double_panel:
   layout: 'services'
-  heading: "FivexL Retainer Plans"
+  heading: "FivexL Managed AWS Support"
   subheading: "Continued Success for Our Valued Customers"
   icon_links:
     - { url: "https://github.com/fivexl", icon: "github" }
     - { url: "https://www.linkedin.com/company/5xl", icon: "linkedin" }
-  button_cta: { url: "#retainer-popup", text: "Get a Retainer Quote" }
+  button_cta: { url: "#retainer-popup", text: "Get a Quote" }
   media_panel: { image: "/contact/featured.png" }
 ---
 
-{{< our_team heading="Retainer Plans for Existing Customers" cta_url="#retainer-popup" cta_text="Get a Retainer Quote" >}}
+{{< our_team heading="Managed AWS Support for Existing Customers" cta_url="#retainer-popup" cta_text="Get a Quote" >}}
 {{< md >}}
 After successfully completing a fixed-price project or a full-time consulting engagement with FivexL, we're committed to ensuring your continued success.
 
-Our Retainer Plans are specially designed for our existing customers, offering tailored support that ranges depending on your needs. Explore our comparison below to identify the plan that aligns seamlessly with your ongoing needs.
+Our Managed AWS Support plans are specially designed for our existing customers, offering tailored support that ranges depending on your needs. Explore our comparison below to identify the plan that aligns seamlessly with your ongoing needs.
 {{< /md >}}
 {{< /our_team >}}
 
@@ -125,7 +125,7 @@ As a business owner with a team of mid-level DevOps specialists, you need someon
   <div class="retainer-popup-content">
     <button id="retainer-popup-close" class="retainer-popup-close">&times;</button>
     <div class="retainer-popup-body">
-      <h2 class="retainer-popup-title">Get a Retainer Quote</h2>
+      <h2 class="retainer-popup-title">Get a Quote</h2>
       <p class="retainer-popup-subtitle">Tell us about your infrastructure needs and we'll get back to you shortly.</p>
       <div id="retainer-hubspot-form"></div>
     </div>

--- a/themes/example/assets/sass/components/two_columns.scss
+++ b/themes/example/assets/sass/components/two_columns.scss
@@ -2,16 +2,19 @@
   background: #DDDDDD53;
   box-sizing: border-box;
   &-Heading {
+    @include base-text;
+    font-size: clamp(2.125rem, 4vw, 3.4rem);
     color: $textSecondary;
-    font-size: clamp(2.125rem,4vw, 3.4rem);
-    margin-top: 0;
-    margin-bottom: 0.5rem;
-    
+    margin-bottom: 2rem;
+    margin-inline: auto;
+    text-align: center;
+    line-height: 1.15;
+
     &_Centered {
       text-align: center;
     }
   }
-  
+
   &-Subheading {
     color: $textSecondary;
     font-size: clamp(1.25rem, 1.5vw, 1.5rem);
@@ -47,29 +50,32 @@
         line-height: 1.5;
       }
     }
-    
+
     ul, ol {
-      padding-left: 1.25rem;
+      padding-left: 0;
       margin: 0;
+      list-style: none;
     }
-    
-    // When a list is the first element in a column (no heading), add top spacing
-    // to align with text in adjacent column that has a heading
-    > *:nth-child(2) > ul:first-child,
-    > *:nth-child(2) > ol:first-child {
-      margin-top: clamp(5rem, 5.5vw, 6rem);
-    }
-    
+
     li {
-      font-size: clamp(0.875rem, 1vw, 1.25rem);
-      font-weight: 500;
-      line-height: 1.6;
-      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      gap: clamp(0.5rem, 2vw, 2rem);
+      background: white;
+      border-radius: 15rem;
+      padding: clamp(1rem, 2vw, 1.5rem) clamp(1rem, 2vw, 2rem) clamp(1rem, 2vw, 1.5rem) clamp(1.5rem, 3vw, 4rem);
+      margin-bottom: clamp(1rem, 2vw, 2.5rem);
+      font-size: clamp(0.875rem, 2vw, 1.25rem);
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      line-height: 1.5;
+      color: $textPrimary;
+      strong { color: inherit; }
     }
-    
+
     &_Centered {
       text-align: center;
-      
+
       p {
         max-width: 900px;
         margin-left: auto;

--- a/themes/example/assets/sass/customer_logos.scss
+++ b/themes/example/assets/sass/customer_logos.scss
@@ -1,0 +1,62 @@
+.clogo {
+  box-sizing: border-box;
+  background: #fff;
+
+  &-Container {
+    padding: clamp(2.5rem, 5vw, 5rem) clamp(1rem, 5vw, 6rem);
+    max-width: 1600px;
+    margin-inline: auto;
+  }
+
+  &-Heading {
+    @include base-text;
+    font-size: clamp(2.125rem, 4vw, 3.4rem);
+    color: $textSecondary;
+    margin-bottom: 3rem;
+    margin-inline: auto;
+    text-align: center;
+    line-height: 1.15;
+  }
+
+  &-Grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0.75rem 1.5rem;
+    align-items: center;
+    justify-items: center;
+    max-width: 900px;
+    margin-inline: auto;
+    @media (min-width: 640px) {
+      grid-template-columns: repeat(3, auto);
+      gap: 1.5rem 2.5rem;
+    }
+    @media (min-width: 1024px) {
+      grid-template-columns: repeat(4, auto);
+    }
+  }
+
+  &-Item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+  }
+
+  &-Logo {
+    max-height: 60px;
+    max-width: 120px;
+    @media (min-width: 640px) {
+      max-height: 160px;
+      max-width: 360px;
+    }
+    width: auto;
+    filter: grayscale(100%);
+    opacity: 0.7;
+    transition: filter 0.2s, opacity 0.2s;
+
+    &:hover {
+      filter: grayscale(0%);
+      opacity: 1;
+    }
+  }
+}

--- a/themes/example/assets/sass/latest_posts.scss
+++ b/themes/example/assets/sass/latest_posts.scss
@@ -1,0 +1,98 @@
+.lp {
+  box-sizing: border-box;
+
+  &-Container {
+    padding: clamp(3.25rem, 6vw, 6rem) clamp(1rem, 5vw, 6rem);
+    max-width: 1600px;
+    margin-inline: auto;
+  }
+
+  &-Heading {
+    @include base-text;
+    font-size: clamp(2.125rem, 4vw, 3.4rem);
+    color: $textSecondary;
+    margin-bottom: 2rem;
+    margin-inline: auto;
+    text-align: center;
+    line-height: 1.15;
+  }
+
+  &-Grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    @media (min-width: 640px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    @media (min-width: 1024px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  &-Card {
+    display: flex;
+    flex-direction: column;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    border: 1.5px solid rgba(0, 0, 0, 0.08);
+    background: #fff;
+    transition: box-shadow 0.2s;
+
+    &:hover {
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+    }
+
+    &_Image {
+      width: 100%;
+      height: 220px;
+      object-fit: cover;
+      display: block;
+    }
+
+    &_Body {
+      display: flex;
+      flex-direction: column;
+      padding: 1.5rem;
+      flex-grow: 1;
+    }
+
+    &_Date {
+      font-size: 0.8rem;
+      color: #888;
+      margin-bottom: 0.5rem;
+      display: block;
+    }
+
+    &_Title {
+      font-size: clamp(1rem, 1.25vw, 1.25rem);
+      font-weight: 700;
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+      line-height: 1.35;
+      a {
+        color: $textPrimary;
+        text-decoration: none;
+        &:hover { color: $accentColor; }
+      }
+    }
+
+    &_Summary {
+      font-size: clamp(0.875rem, 1vw, 1rem);
+      font-weight: 400;
+      line-height: 1.6;
+      color: #444;
+      margin: 0;
+      flex-grow: 1;
+    }
+
+    &_Link {
+      display: inline-block;
+      margin-top: 1.25rem;
+      font-size: 0.875rem;
+      font-weight: 700;
+      color: $accentColor;
+      text-decoration: none;
+      &:hover { text-decoration: underline; }
+    }
+  }
+}

--- a/themes/example/assets/sass/main.scss
+++ b/themes/example/assets/sass/main.scss
@@ -40,6 +40,9 @@ p:empty {
 @import 'infra_clinic.scss';
 @import 'retainer.scss';
 @import 'components';
+@import 'services_grid';
+@import 'latest_posts';
+@import 'customer_logos';
 
 * {
   box-sizing: border-box;

--- a/themes/example/assets/sass/services_grid.scss
+++ b/themes/example/assets/sass/services_grid.scss
@@ -1,0 +1,81 @@
+.svc {
+  box-sizing: border-box;
+
+  &-Container {
+    padding: clamp(3.25rem, 6vw, 6rem) clamp(1rem, 5vw, 6rem);
+    max-width: 1600px;
+    margin-inline: auto;
+  }
+
+  &-Heading {
+    @include base-text;
+    font-size: clamp(2.125rem, 4vw, 3.4rem);
+    color: $textSecondary;
+    margin-bottom: 2rem;
+    margin-inline: auto;
+    text-align: center;
+    line-height: 1.15;
+    @media (min-width: 768px) {
+      margin-bottom: 2rem;
+    }
+  }
+
+  &-Grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+    @media (min-width: 640px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    @media (min-width: 1024px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  &-Card {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem;
+    border-radius: 0.75rem;
+    border: 1.5px solid rgba(0, 0, 0, 0.1);
+    background: #fff;
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.2s, box-shadow 0.2s;
+
+    &:hover {
+      border-color: $accentColor;
+      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
+    }
+
+    &_Title {
+      font-size: clamp(1rem, 1.25vw, 1.25rem);
+      font-weight: 700;
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+      color: $textPrimary;
+    }
+
+    &_Description {
+      font-size: clamp(0.875rem, 1vw, 1rem);
+      font-weight: 400;
+      line-height: 1.6;
+      color: #444;
+      margin: 0;
+      flex-grow: 1;
+    }
+
+    &_Link {
+      display: inline-block;
+      margin-top: 1.25rem;
+      font-size: 0.875rem;
+      font-weight: 700;
+      color: $accentColor;
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/themes/example/assets/sass/steps_section.scss
+++ b/themes/example/assets/sass/steps_section.scss
@@ -17,6 +17,9 @@
     margin-top: 0;
     margin-bottom: 3rem;
     font-size: clamp(2.125rem,4vw, 3.4rem);
+    text-align: center;
+    width: 100%;
+    display: block;
   }
 
   &-StepsWrapper {

--- a/themes/example/layouts/shortcodes/customer_logos.html
+++ b/themes/example/layouts/shortcodes/customer_logos.html
@@ -1,0 +1,25 @@
+{{ $cases := where site.RegularPages "Params.case_study" true }}
+{{ $seen := slice }}
+
+<section class="clogo">
+    <div class="clogo-Container">
+        {{ with .Params.heading }}<h2 class="clogo-Heading">{{ . }}</h2>{{ end }}
+        <div class="clogo-Grid">
+            {{ range $cases }}
+                {{ $page := . }}
+                {{ with .Params.about_company.logo }}
+                    {{ if and (ne . "startup.png") (not (in $seen .)) }}
+                        {{ $seen = $seen | append . }}
+                        {{ with $page.Resources.GetMatch . }}
+                        <div class="clogo-Item">
+                            <a href="{{ $page.Permalink }}">
+                                <img class="clogo-Logo" src="{{ .Permalink }}" alt="{{ $page.Title }}">
+                            </a>
+                        </div>
+                        {{ end }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        </div>
+    </div>
+</section>

--- a/themes/example/layouts/shortcodes/latest_posts.html
+++ b/themes/example/layouts/shortcodes/latest_posts.html
@@ -1,0 +1,29 @@
+{{ $blogs := where site.RegularPages "Section" "blog" }}
+{{ $cases := where site.RegularPages "Params.case_study" true }}
+{{ $all := union $blogs $cases }}
+{{ $sorted := sort $all "Date" "desc" }}
+{{ $latest := first 3 $sorted }}
+
+<section class="lp">
+    <div class="lp-Container">
+        {{ with .Params.heading }}<h2 class="lp-Heading">{{ . }}</h2>{{ end }}
+        <div class="lp-Grid">
+            {{ range $latest }}
+            {{ $permalink := .Permalink }}
+            <div class="lp-Card">
+                {{ with .Resources.GetMatch .Params.panel_image }}
+                <a href="{{ $permalink }}">
+                    {{ partial "img" (dict "class" "lp-Card_Image" "src" .Permalink "image" . "alt" .Name "sizes" "(max-width: 767px) 100vw, 500px" "lazy" true) }}
+                </a>
+                {{ end }}
+                <div class="lp-Card_Body">
+                    <span class="lp-Card_Date">{{ time.Format "January 2, 2006" .Params.date }}</span>
+                    <h3 class="lp-Card_Title"><a href="{{ $permalink }}">{{ .Title }}</a></h3>
+                    <p class="lp-Card_Summary">{{ .Summary | plainify | truncate 160 }}</p>
+                    <a class="lp-Card_Link" href="{{ $permalink }}">Read more →</a>
+                </div>
+            </div>
+            {{ end }}
+        </div>
+    </div>
+</section>

--- a/themes/example/layouts/shortcodes/service_item.html
+++ b/themes/example/layouts/shortcodes/service_item.html
@@ -1,0 +1,12 @@
+{{ if .Params.url }}
+<a class="svc-Card" href="{{ .Params.url }}">
+    <h3 class="svc-Card_Title">{{ .Params.title }}</h3>
+    <p class="svc-Card_Description">{{ .Params.description }}</p>
+    <span class="svc-Card_Link">Learn more →</span>
+</a>
+{{ else }}
+<div class="svc-Card">
+    <h3 class="svc-Card_Title">{{ .Params.title }}</h3>
+    <p class="svc-Card_Description">{{ .Params.description }}</p>
+</div>
+{{ end }}

--- a/themes/example/layouts/shortcodes/services_grid.html
+++ b/themes/example/layouts/shortcodes/services_grid.html
@@ -1,0 +1,8 @@
+<section class="svc">
+    <div class="svc-Container">
+        {{ with .Params.heading }}<h2 class="svc-Heading">{{ . }}</h2>{{ end }}
+        <div class="svc-Grid">
+            {{ .Inner }}
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
- Replace bullet list with services_grid shortcode — clickable cards with title, description, and CTA
- Add customer_logos section with grayscale logos linked to case studies
- Add latest_posts section showing 3 most recent blog posts and case studies
- Style Why Startups Choose FivexL list as pill boxes matching How It Works section
- Center all section headings to match Our Happy Customers style
- Update homepage copy: drop em dashes, trim CTA heading text