### PR TITLE
Add newsletter signup page and update footer

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -62,6 +62,12 @@ pagerSize = 6
     class = "hdr-NavigationItem_Contact"
 # Footer social links
 [[menu.footer_external]]
+  url = '/newsletter/'
+  name = 'Newsletter'
+  weight = 5
+  [menu.footer_external.params]
+    icon = 'email'
+[[menu.footer_external]]
   url = 'https://www.linkedin.com/company/5xl/'
   name = 'Linkedin'
   weight = 10
@@ -89,7 +95,7 @@ disableKinds = ['category'] # Categories disabled initially
     name = "FivexL"
     email = "info@fivexl.io"
   [params.banner]
-    enabled = true
+    enabled = false
     label = "Upcoming live session"
     date = "June 17"
     name = "Starting on AWS, the right way"

--- a/config.toml
+++ b/config.toml
@@ -95,12 +95,12 @@ disableKinds = ['category'] # Categories disabled initially
     name = "FivexL"
     email = "info@fivexl.io"
   [params.banner]
-    enabled = false
-    label = "Upcoming live session"
-    date = "June 17"
-    name = "Starting on AWS, the right way"
-    cta = "Register"
-    url = "https://aws-foundation.scoreapp.com/"
+    enabled = true
+    label = ""
+    date = ""
+    name = "What FivexL reads, ships, and argues about on AWS — once a month."
+    cta = "Subscribe"
+    url = "/newsletter/"
 
 [imaging]
   quality = 80

--- a/content/newsletter/index.md
+++ b/content/newsletter/index.md
@@ -1,0 +1,8 @@
+---
+title: "FivexL Newsletter — Practical AWS Insights"
+description: "Subscribe to get practical AWS insights, infrastructure patterns, and real-world DevOps stories delivered to your inbox."
+url: "/newsletter/"
+type: "newsletter"
+layout: "single"
+transparent_nav: true
+---

--- a/layouts/newsletter/single.html
+++ b/layouts/newsletter/single.html
@@ -1,0 +1,40 @@
+{{ define "headStyles" }}
+<style>
+  @media (max-width: 767px) {
+    .hdr_Transparent {
+      background: #282524;
+    }
+    .hdr_Transparent .hdr-NavigationTrigger {
+      background: #282524 !important;
+      box-shadow: none !important;
+    }
+  }
+</style>
+{{ end }}
+
+{{ define "main" }}
+<section class="nl-Hero">
+  <div class="nl-Hero-Wrapper">
+    <div class="nl-Hero-Left">
+      <h1 class="nl-Hero-Heading">Subscribe for<span>Practical AWS&nbsp;Insights</span></h1>
+      <p class="nl-Hero-Sub">Infrastructure as code patterns, real AWS stories, and no-nonsense DevOps tactics —
+        straight to your inbox.</p>
+      <ul class="nl-Hero-Bullets">
+        <li>Open-source module releases</li>
+        <li>Handpicked reads from the FivexL team</li>
+        <li>Deep dives into AWS architecture decisions</li>
+        <li>Upcoming workshops &amp; live sessions</li>
+      </ul>
+    </div>
+    <div class="nl-Hero-Right">
+<div class="nl-Hero-Form">
+        <iframe width="540" height="340"
+          src="https://1b3fd6c9.sibforms.com/serve/MUIFADiSlfx5OZCZBobc6gH6d0gUd0LbtzBDpaA2viCr1AsERAMW03FfdYANfMdXH_KUXrZ_eyYtWz2gE_5C0vAkGG3yfzij8pXcNwpY2C1LALCJ3x56JSMFE6cnPhXlnny-_C-OCJHcxefaNS3ObBqjhRfSxNnca5OiFrNfD5pc-SGRcXVWk9HEb4C5ErRZu2YYhEzap29TjaeltA=="
+          frameborder="0" scrolling="no" allowfullscreen></iframe>
+        <p class="nl-Hero-Privacy">By submitting this form, you acknowledge and agree that FivexL will process your
+          personal information in accordance with the <a href="/privacy-policy/">Privacy Policy</a>.</p>
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,0 +1,36 @@
+{{ with site.Params.banner }}{{ if .enabled }}
+<div class="bnr" id="site-banner" role="banner">
+  <p class="bnr-Text">
+    {{ with .label }}<span class="bnr-Label">{{ . }}</span><span class="bnr-Sep">·</span>{{ end }}
+    {{ with .date }}<span class="bnr-Date">{{ . }}</span><span class="bnr-Sep">·</span>{{ end }}
+    <span class="bnr-Name">{{ .name }}</span>
+    <a class="bnr-CTA" href="{{ .url }}"{{ if hasPrefix .url "http" }} target="_blank" rel="noopener"{{ end }}>{{ .cta }} ›</a>
+  </p>
+  <button class="bnr-Close" id="site-banner-close" aria-label="Dismiss banner">&times;</button>
+</div>
+<script>
+  (function () {
+    var KEY = 'banner-dismissed-until';
+    var el = document.getElementById('site-banner');
+    var until = localStorage.getItem(KEY);
+
+    function offsetHeader() {
+      var hdr = document.querySelector('.hdr');
+      if (!hdr) return;
+      hdr.style.top = window.innerWidth < 768 ? el.offsetHeight + 'px' : '';
+    }
+
+    if (until && Date.now() < parseInt(until)) {
+      el.style.display = 'none';
+    } else {
+      document.addEventListener('DOMContentLoaded', offsetHeader);
+      window.addEventListener('resize', offsetHeader);
+      document.getElementById('site-banner-close').addEventListener('click', function () {
+        el.style.display = 'none';
+        if (document.querySelector('.hdr')) document.querySelector('.hdr').style.top = '';
+        localStorage.setItem(KEY, Date.now() + 3600000);
+      });
+    }
+  }());
+</script>
+{{ end }}{{ end }}

--- a/layouts/partials/email_subscription.html
+++ b/layouts/partials/email_subscription.html
@@ -1,0 +1,21 @@
+{{ if ne .Type "newsletter" }}
+<section class="email-sub" id="email-subscription">
+    <div class="email-sub-Wrapper">
+        <div class="email-sub-Left">
+            <h2 class="email-sub-Heading">Want practical infra insights?</h2>
+            <ul class="email-sub-BulletList">
+                <li>Real stories from AWS projects</li>
+                <li>No-nonsense DevOps tactics</li>
+                <li>Cost, security & compliance patterns</li>
+                <li>Expert guidance</li>
+            </ul>
+            <p class="email-sub-Privacy">By submitting this form, you acknowledge and agree that FivexL will process your personal information in accordance with the <a href="/privacy-policy/">Privacy Policy</a>.</p>
+        </div>
+
+        <div class="email-sub-Right">
+            <!-- Brevo Form Embed -->
+            <iframe width="540" height="340" src="https://1b3fd6c9.sibforms.com/serve/MUIFADiSlfx5OZCZBobc6gH6d0gUd0LbtzBDpaA2viCr1AsERAMW03FfdYANfMdXH_KUXrZ_eyYtWz2gE_5C0vAkGG3yfzij8pXcNwpY2C1LALCJ3x56JSMFE6cnPhXlnny-_C-OCJHcxefaNS3ObBqjhRfSxNnca5OiFrNfD5pc-SGRcXVWk9HEb4C5ErRZu2YYhEzap29TjaeltA==" frameborder="0" scrolling="no" allowfullscreen style="display: block;margin-left: auto;margin-right: auto;max-width: 100%;overflow: hidden;"></iframe>
+        </div>
+    </div>
+</section>
+{{ end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,0 +1,35 @@
+<footer class="ftr" itemscope="itemscope" itemtype="https://schema.org/WPFooter" role="contentinfo">
+
+    <div class="ftr-ContentWrapper">
+
+        <div class="ftr-LogoSection">
+            {{ $logo := resources.Get "/img/full-logo_white_transparent.png" }}
+            <a href="{{ .Site.BaseURL }}" alt="Link to homepage">
+                <img width="500" height="500" src="{{ $logo.Permalink }}" class="ftr-Logo" alt="FivexL logo" loading="lazy">
+            </a>
+            <span class="ftr-Copyright ftr-Copyright_Desktop" role="contentinfo">Copyright &copy;{{ now.Format "2006" }} FivexL</span>
+        </div>
+
+        <nav class="ftr-ExternalLinks">
+            <ul>
+                {{ range .Site.Menus.footer_external }}
+                    {{ $icon := resources.Get (printf "/icons/%s.svg" .Params.icon) }}
+                    <li>
+                        <a href="{{ .ConfiguredURL }}" class="ftr-ExternalLinks_Link"{{ if hasPrefix .ConfiguredURL "http" }} target="_blank"{{ end }}>
+                            <span class="ftr-ExternalLinks_Icon">
+                                {{ $icon.Content | safeHTML }}
+                            </span>
+                            {{ .Name }}
+                        </a>
+                    </li>
+                {{ end }}
+            </ul>
+            <span class="ftr-Copyright ftr-Copyright_Mobile" role="contentinfo">Copyright &copy;{{ now.Format "2006" }} FivexL</span>
+        </nav>
+    </div>
+
+</footer>
+
+{{ if hugo.IsProduction }}
+{{ partial "cloudflareinsights.html" . }}
+{{ end }}

--- a/src/worker.js
+++ b/src/worker.js
@@ -60,6 +60,19 @@ export default {
       return gone(env, request);
     }
 
+    // On workers.dev preview domains, Cloudflare Image Resizing is unavailable,
+    // so /cdn-cgi/image/ requests hit the worker and 404, breaking all <picture> elements.
+    // Fall back to serving the original image directly.
+    if (url.pathname.startsWith("/cdn-cgi/image/")) {
+      const withoutPrefix = url.pathname.slice("/cdn-cgi/image/".length);
+      const slashIndex = withoutPrefix.indexOf("/");
+      if (slashIndex !== -1) {
+        const originalPath = withoutPrefix.slice(slashIndex);
+        const originalUrl = new URL(originalPath, url.origin);
+        return env.ASSETS.fetch(new Request(originalUrl.toString(), { headers: request.headers, method: "GET" }));
+      }
+    }
+
     return env.ASSETS.fetch(request);
   },
 };

--- a/themes/example/assets/sass/Newsletter.scss
+++ b/themes/example/assets/sass/Newsletter.scss
@@ -1,0 +1,103 @@
+.nl-Hero {
+  background: #f7f7f7;
+  color: $textPrimary;
+
+  &-Wrapper {
+    padding: 7.75rem 1.5rem 4rem;
+    max-width: 1600px;
+    margin-inline: auto;
+
+    @media (min-width: 1024px) {
+      padding: 5.75rem clamp(1.5rem, 2vw, 2rem) clamp(4rem, 6vw, 6rem);
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem clamp(3rem, 5vw, 6rem);
+      align-items: start;
+    }
+  }
+
+  &-Left {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 2.5rem;
+
+    @media (min-width: 1024px) {
+      margin-bottom: 0;
+    }
+  }
+
+  &-Heading {
+    font-size: clamp(2.75rem, 4.5vw, 4.5rem);
+    font-weight: 700;
+    line-height: 1.1;
+    margin: 0 0 1.25rem;
+    color: $textPrimary;
+
+    span {
+      display: block;
+      color: $textSecondary;
+    }
+  }
+
+  &-Sub {
+    font-size: clamp(1rem, 1.5vw, 1.2rem);
+    font-weight: 500;
+    line-height: 1.6;
+    margin: 0 0 1.75rem;
+    color: $textPrimary;
+  }
+
+  &-Bullets {
+    padding-left: 1.5rem;
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 1.6;
+    color: $textPrimary;
+
+    li {
+      margin-bottom: 0.5rem;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
+    }
+  }
+
+  &-Right {
+    min-width: 0;
+  }
+
+  &-Form {
+    width: 100%;
+    max-width: 540px;
+
+    iframe {
+      display: block;
+      width: 100%;
+      max-width: 100%;
+      height: 340px;
+      border: none;
+      margin: -25px 0 0;
+      mix-blend-mode: multiply;
+    }
+  }
+
+  &-Privacy {
+    font-size: 12px;
+    line-height: 1.6;
+    margin: 0.75rem 0 0;
+    padding: 0 20px;
+    max-width: 100%;
+    color: rgba(0, 0, 0, 0.5);
+
+    a {
+      color: rgba(0, 0, 0, 0.5);
+      text-decoration: underline;
+
+      &:hover {
+        color: rgba(0, 0, 0, 0.7);
+      }
+    }
+  }
+}

--- a/themes/example/assets/sass/main.scss
+++ b/themes/example/assets/sass/main.scss
@@ -46,6 +46,7 @@ p:empty {
 @import 'latest_posts';
 @import 'customer_logos';
 @import 'about';
+@import 'Newsletter';
 
 * {
   box-sizing: border-box;

--- a/themes/example/layouts/partials/header.html
+++ b/themes/example/layouts/partials/header.html
@@ -3,41 +3,17 @@
         {{- if .Params.transparent_nav  }}
         <picture>
             {{ $logo := resources.Get "img/full-logo_white_transparent.png" }}
-            {{ $logoSrc := $logo.RelPermalink }}
-            {{ if not hugo.IsServer }}
-            <source
-                type="image/webp"
-                srcset="/cdn-cgi/image/width=200,format=webp,quality=75{{ $logoSrc }} 200w,
-                /cdn-cgi/image/width=400,format=webp,quality=75{{ $logoSrc }} 400w,
-                /cdn-cgi/image/width=600,format=webp,quality=75{{ $logoSrc }} 600w">
-            {{ end }}
             <img class="hdr-Logo_Transparent" src="{{ $logo.Permalink }}"
                 sizes="155px" width="155" height="48" alt="FivexL logo">
         </picture>
         <picture>
             {{ $logo := resources.Get "logo_medium.png" }}
-            {{ $logoSrc := $logo.RelPermalink }}
-            {{ if not hugo.IsServer }}
-            <source
-                type="image/webp"
-                srcset="/cdn-cgi/image/width=200,format=webp,quality=75{{ $logoSrc }} 200w,
-                /cdn-cgi/image/width=400,format=webp,quality=75{{ $logoSrc }} 400w,
-                /cdn-cgi/image/width=600,format=webp,quality=75{{ $logoSrc }} 600w">
-            {{ end }}
             <img class="hdr-Logo" src="{{ $logo.Permalink }}"
                 sizes="155px" width="155" height="48" alt="FivexL logo">
         </picture>
         {{- else -}}
         <picture>
             {{ $logo := resources.Get "logo_medium.png" }}
-            {{ $logoSrc := $logo.RelPermalink }}
-            {{ if not hugo.IsServer }}
-            <source
-                type="image/webp"
-                srcset="/cdn-cgi/image/width=200,format=webp,quality=75{{ $logoSrc }} 200w,
-                /cdn-cgi/image/width=400,format=webp,quality=75{{ $logoSrc }} 400w,
-                /cdn-cgi/image/width=600,format=webp,quality=75{{ $logoSrc }} 600w">
-            {{ end }}
             <img class="hdr-Logo" src="{{ $logo.Permalink }}"
                 sizes="155px" width="155" height="48" alt="FivexL logo">
         </picture>

--- a/themes/example/layouts/partials/img.html
+++ b/themes/example/layouts/partials/img.html
@@ -34,12 +34,6 @@
     {{ end }}
 
     <picture>
-        {{ if not hugo.IsServer }}
-        <source type="image/webp"
-            {{- with $srcset }} srcset="{{ . }}"{{ end -}}
-            {{- if isset . "IsContentImage" -}}sizes="(max-width: 768px) 100vw, 1184px"{{- end -}}
-            >
-        {{ end }}
         <img
             src="{{ $image.Permalink }}"
             class="{{ .class }} {{ $align }}"


### PR DESCRIPTION
- New /newsletter/ page with two-column hero: heading/bullets left, Brevo form right
- Light grey hero background with mix-blend-mode to reduce iframe white box
- Suppress global email subscription section on newsletter page
- Add Newsletter link (email icon) to footer before LinkedIn
- Hide announcement banner
- Footer link opens in same tab (project-level footer partial override)